### PR TITLE
feat: support lint opts

### DIFF
--- a/run.js
+++ b/run.js
@@ -60,13 +60,27 @@ function getHistoryCommits(from, to) {
   })
 }
 
+function getOptsFromConfig(config) {
+  return {
+    parserOpts:
+      config.parserPreset != null && config.parserPreset.parserOpts != null
+        ? config.parserPreset.parserOpts
+        : {},
+    plugins: config.plugins != null ? config.plugins : {},
+    ignores: config.ignores != null ? config.ignores : [],
+    defaultIgnores:
+      config.defaultIgnores != null ? config.defaultIgnores : true,
+  }
+}
+
 const showLintResults = async ([from, to]) => {
   const commits = await getHistoryCommits(from, to)
   const config = existsSync(configPath)
     ? await load({}, { file: configPath })
     : {}
+  const opts = getOptsFromConfig(config)
   const results = await Promise.all(
-    commits.map(commit => lint(commit, config.rules)),
+    commits.map(commit => lint(commit, config.rules, opts)),
   )
   const formattedResults = format(
     { results },


### PR DESCRIPTION
This PR enables to pass `opts` param to lint API.
related `@commitlint/cli`'s code: https://github.com/conventional-changelog/commitlint/blob/75cef4e8f74e180cf4c601afde295f2c35336b58/%40commitlint/cli/src/cli.js#L152