### PR TITLE
Added plugin with jira rules for `commitlint-config-jira`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2364,17 +2364,25 @@
       "optional": true
     },
     "commitlint-config-jira": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/commitlint-config-jira/-/commitlint-config-jira-1.0.9.tgz",
-      "integrity": "sha512-1+MiKbrj6hkUmRhxMFqskGDTu/riXMgtbpHUCI9mSrHHPi+/ZjfWTHYQvh/GyM59JCAJVLiJcI3rFMAx/RjAsA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/commitlint-config-jira/-/commitlint-config-jira-1.1.0.tgz",
+      "integrity": "sha512-cZayDuX6j4cXcuRCJSwQAC+UPVvc47EHRjKa42ECiNSlrEA7SftewxheOydnP5eOFRe0CvMp5YpXdTBgEUnVNQ==",
       "requires": {
-        "commitlint-jira-utils": "1.0.12"
+        "commitlint-jira-utils": "1.1.0"
       }
     },
     "commitlint-jira-utils": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/commitlint-jira-utils/-/commitlint-jira-utils-1.0.12.tgz",
-      "integrity": "sha512-9WHMRiqiTcRW1O8RsJmGgwRYlzCTjpf3tA7fYXhMl4dhKbGE/wfrx04iO8ZoVKxBhjB8mL/3qD+IR/vhJeLsFg=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/commitlint-jira-utils/-/commitlint-jira-utils-1.1.0.tgz",
+      "integrity": "sha512-GjMeflTKWAy/s2GzLt8Cxqzc7JA8+VpbwpB2LoYBokHJzXV2a8zHddCOGk6c2lx2CmUEmU0YWg3BYPjZDtWyow=="
+    },
+    "commitlint-plugin-jira-rules": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/commitlint-plugin-jira-rules/-/commitlint-plugin-jira-rules-1.1.0.tgz",
+      "integrity": "sha512-2+qWePOBpfpY14DYI5DQEfHjb2zRt5wMUc0L8CtMIuzX0+aAVUUj+ypL2mF170IoqPs15S5GcDQDKeN5YH4WuQ==",
+      "requires": {
+        "commitlint-jira-utils": "1.1.0"
+      }
     },
     "compare-func": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@commitlint/format": "8.2.0",
     "@commitlint/lint": "8.2.0",
     "@commitlint/load": "8.2.0",
-    "commitlint-config-jira": "1.0.9",
+    "commitlint-config-jira": "1.1.0",
+    "commitlint-plugin-jira-rules": "1.1.0",
     "conventional-changelog-lint-config-canonical": "1.0.0",
     "git-raw-commits": "2.0.2",
     "lerna": "3.18.1"


### PR DESCRIPTION
The plugin containing rules to be used by `commitlint-config-jira` was missing from the `package.json`.  This means that when extending `['jira']` in the `commitlint.config.js` it was always failing due to unknown rules.

This fixes #13 and allows easy usage of the `commitlint-config-jira`.