### PR TITLE
Add support for @elevai/commitlint-plugin-github.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This is a [`Docker` action](https://github.com/actions/toolkit/blob/e2adf403d6d1
 - [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
 - [@commitlint/config-lerna-scopes](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-lerna-scopes)
 - [@commitlint/config-patternplate](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-patternplate)
+- [@elevai/commitlint-config-github](https://github.com/elevai-consulting/commitlint-github/)
 - [conventional-changelog-lint-config-canonical](https://github.com/gajus/conventional-changelog-lint-config-canonical)
 - [commitlint-config-jira](https://github.com/Gherciu/commitlint-jira)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -415,6 +415,64 @@
       "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-8.2.0.tgz",
       "integrity": "sha512-LXTYG3sMenlN5qwyTZ6czOULVcx46uMy+MEVqpvCgptqr/MZcV/C2J+S2o1DGwj1gOEFMpqrZaE3/1R2Q+N8ng=="
     },
+    "@elevai/commitlint-config-github": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@elevai/commitlint-config-github/-/commitlint-config-github-0.1.0.tgz",
+      "integrity": "sha512-Wz/sE5BZLiWdkGlHCR5hls0lBbsDlJA+uJebyE8XBvfciLt5P1MEW3fGg64jrcCpGbzP6+GxKhInXliLfuOQlQ==",
+      "requires": {
+        "@elevai/commitlint-github-utils": "^0.1.0"
+      }
+    },
+    "@elevai/commitlint-github-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@elevai/commitlint-github-utils/-/commitlint-github-utils-0.1.0.tgz",
+      "integrity": "sha512-4APAaplw2dV85hXCCKet9rHgv9REMNNSvry0GNpZFMR9G2hY+2FVCPj2VJDt42RTZTVR1mfB1KngH/M/NHsaKA=="
+    },
+    "@elevai/commitlint-plugin-github": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@elevai/commitlint-plugin-github/-/commitlint-plugin-github-0.1.0.tgz",
+      "integrity": "sha512-BAzlRGu3tOuP9yrr5gsNIwCM8IKtmnwTU5//4GGpYY7fktufb+IwRVMVhUBTV2e0BmAn6llWQ4h2XaMLmC+YFQ==",
+      "requires": {
+        "@commitlint/rules": "^8.3.4",
+        "@elevai/commitlint-github-utils": "^0.1.0"
+      },
+      "dependencies": {
+        "@commitlint/ensure": {
+          "version": "8.3.4",
+          "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-8.3.4.tgz",
+          "integrity": "sha512-8NW77VxviLhD16O3EUd02lApMFnrHexq10YS4F4NftNoErKbKaJ0YYedktk2boKrtNRf/gQHY/Qf65edPx4ipw==",
+          "requires": {
+            "lodash": "4.17.15"
+          }
+        },
+        "@commitlint/message": {
+          "version": "8.3.4",
+          "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-8.3.4.tgz",
+          "integrity": "sha512-nEj5tknoOKXqBsaQtCtgPcsAaf5VCg3+fWhss4Vmtq40633xLq0irkdDdMEsYIx8rGR0XPBTukqzln9kAWCkcA=="
+        },
+        "@commitlint/rules": {
+          "version": "8.3.4",
+          "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-8.3.4.tgz",
+          "integrity": "sha512-xuC9dlqD5xgAoDFgnbs578cJySvwOSkMLQyZADb1xD5n7BNcUJfP8WjT9W1Aw8K3Wf8+Ym/ysr9FZHXInLeaRg==",
+          "requires": {
+            "@commitlint/ensure": "^8.3.4",
+            "@commitlint/message": "^8.3.4",
+            "@commitlint/to-lines": "^8.3.4",
+            "babel-runtime": "^6.23.0"
+          }
+        },
+        "@commitlint/to-lines": {
+          "version": "8.3.4",
+          "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-8.3.4.tgz",
+          "integrity": "sha512-5AvcdwRsMIVq0lrzXTwpbbG5fKRTWcHkhn/hCXJJ9pm1JidsnidS1y0RGkb3O50TEHGewhXwNoavxW9VToscUA=="
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
+      }
+    },
     "@evocateur/libnpmaccess": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@commitlint/format": "8.2.0",
     "@commitlint/lint": "8.2.0",
     "@commitlint/load": "8.2.0",
+    "@elevai/commitlint-config-github": "^0.1.0",
+    "@elevai/commitlint-plugin-github": "^0.1.0",
     "commitlint-config-jira": "1.2.0",
     "commitlint-plugin-jira-rules": "1.2.0",
     "conventional-changelog-lint-config-canonical": "1.0.0",


### PR DESCRIPTION
Thanks so much for creating this GitHub Action, it inspired me to create a custom commitlint plugin to support the commit message conventions we use on our projects:

https://github.com/elevai-consulting/commitlint-github/

This has been published to npm, and so I've created this PR to add the following node dependencies so that my commitlint config file can successfully reference them from the Docker container you create in the Action:

- [@elevai/commitlint-config-github](https://www.npmjs.com/package/@elevai/commitlint-config-github)
  - This is the package with the default rule configuration.
- [@elevai/commitlint-plugin-github](https://www.npmjs.com/package/@elevai/commitlint-plugin-github)
  - This is the package with the commitlint rule implementations.

For reference below is the error logging I got from attempting to run your Action and it couldn't resolve the packages above as expected:

```
Run wagoid/commitlint-github-action@v1
/usr/bin/docker run --name wagoidcommitlintgithubaction140_37b5b2 --label e87b52 --workdir /github/workspace --rm -e GITHUB_TOKEN -e INPUT_CONFIGFILE -e INPUT_FIRSTPARENT -e INPUT_FAILONWARNINGS -e INPUT_HELPURL -e HOME -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e GITHUB_ACTIONS=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/personnel-app/personnel-app":"/github/workspace" wagoid/commitlint-github-action:1.4.0
##[error]error running commitlint
Cannot find module "@elevai/commitlint-config-github" from "/github/workspace/.github/workflows"
Error: Cannot find module "@elevai/commitlint-config-github" from "/github/workspace/.github/workflows"
    at resolveId (/node_modules/@commitlint/resolve-extends/lib/index.js:89:15)
    at resolveConfig (/node_modules/@commitlint/resolve-extends/lib/index.js:72:24)
    at /node_modules/@commitlint/resolve-extends/lib/index.js:30:24
    at Array.reduce (<anonymous>)
    at loadExtends (/node_modules/@commitlint/resolve-extends/lib/index.js:28:38)
    at resolveExtends (/node_modules/@commitlint/resolve-extends/lib/index.js:15:20)
    at Object.$If_1 (/node_modules/@commitlint/load/lib/index.js:73:45)
    at Object.<anonymous> (/node_modules/@commitlint/load/lib/index.js:154:17)
```

Hopefully it's no problem to add these packages in as they are publicly available on npmjs.com, but let me know if you have any questions etc.

Cheers!