### PR TITLE
feat: use config-conventional as default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The path to your commitlint config file.
 
 Default: `commitlint.config.js`
 
+If the config file doesn't exist, [config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) settings will be loaded as a default fallback.
+
 ### `firstParent`
 
 When set to true, we follow only the first parent commit when seeing a merge commit.

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: Lints Pull Request commit messages with commitlint
 author: Wagner Santos
 inputs:
   configFile:
-    description: Commitlint config file
+    description: Commitlint config file. If the file doesn't exist, config-conventional settings will be loaded as a fallback.
     default: ./commitlint.config.js
     required: false
   firstParent:

--- a/src/action.js
+++ b/src/action.js
@@ -120,11 +120,10 @@ const handleOnlyWarnings = formattedResults => {
 }
 
 const showLintResults = async ([from, to]) => {
-  const failOnWarnings = core.getInput('failOnWarnings')
   const commits = await getHistoryCommits(from, to)
   const config = existsSync(configPath)
     ? await load({}, { file: configPath })
-    : {}
+    : await load({ extends: ['@commitlint/config-conventional'] })
   const opts = getOptsFromConfig(config)
   const lintedCommits = await Promise.all(
     commits.map(async commit => ({

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -60,6 +60,20 @@ describe('Commit Linter action', () => {
     jest.resetModules()
   })
 
+  it('should use default config when config file does not exist', async () => {
+    td.when(core.getInput('configFile')).thenReturn('./not-existing-config.js')
+    cwd = await git.bootstrap('fixtures/conventional')
+    await gitEmptyCommit(cwd, 'wrong message')
+    const [to] = await getCommitHashes(cwd)
+    await createPushEventPayload(cwd, { to })
+    updatePushEnvVars(cwd, to)
+    td.replace(process, 'cwd', () => cwd)
+
+    await runAction()
+
+    td.verify(core.setFailed(contains('You have commit messages with errors')))
+  })
+
   it('should fail for single push with incorrect message', async () => {
     cwd = await git.bootstrap('fixtures/conventional')
     await gitEmptyCommit(cwd, 'wrong message')


### PR DESCRIPTION
When no configFile is given and the `commitlint.config.js` file doesn't exist in the repository, then no config is loaded at all.
This PR brings in the `config-conventional` as default config when the config file does not exist.