### PR TITLE
fix: do not run workflow commands in commit messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12417,6 +12417,11 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
           "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -12428,6 +12433,14 @@
       "requires": {
         "temp-dir": "^2.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "test-exclude": {
@@ -12840,9 +12853,9 @@
       }
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "conventional-changelog-lint-config-canonical": "^1.0.0",
     "dargs": "^7.0.0",
     "execa": "^4.0.3",
-    "lerna": "^3.22.1"
+    "lerna": "^3.22.1",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@commitlint/test": "^9.0.1",

--- a/src/action.js
+++ b/src/action.js
@@ -1,5 +1,6 @@
 const { existsSync } = require('fs')
 const { resolve } = require('path')
+const { v4: uuidv4 } = require('uuid')
 const core = require('@actions/core')
 const github = require('@actions/github')
 const lint = require('@commitlint/lint').default
@@ -135,6 +136,10 @@ const showLintResults = async ([from, to]) => {
 
   generateOutputs(lintedCommits)
 
+  // disable workflow commands
+  const token = uuidv4()
+  console.log(`::stop-commands::${token}`)
+
   if (hasOnlyWarnings(lintedCommits)) {
     handleOnlyWarnings(formattedResults)
   } else if (formattedResults) {
@@ -142,6 +147,9 @@ const showLintResults = async ([from, to]) => {
   } else {
     console.log('Lint free! 🎉')
   }
+
+  // enable workflow commands
+  console.log(`::${token}::`)
 }
 
 const exitWithMessage = message => error => {


### PR DESCRIPTION
The commit message is printed, which may contain workflow commands. See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.