### PR TITLE
ci: replace set-env calls with $GITHUB_ENV file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set VERSION env var
         run: |
           version=`node -p "require('./package.json').version"`
-          echo "::set-env name=VERSION::$version"
+          echo "VERSION=$version" >> $GITHUB_ENV
       - name: Login to docker registry
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
Due to security reasons, ::set-env command doesn't work anymore. The new method of
updating env vars dynamically is through the $GITHUB_ENV file.