### PR TITLE
ci: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: monthly
+      open-pull-requests-limit: 99
+
+    - package-ecosystem: npm
+      directory: /
+      schedule:
+          interval: monthly
+      open-pull-requests-limit: 99


### PR DESCRIPTION
[Snyk](https://snyk.io/test/github/wagoid/commitlint-github-action) is currently reporting a few vulnerable dependencies in this repo.
Adding this dependabot config will enable dependabot for the repo, which will open pull requests to update both GitHub action dependencies and NPM dependencies on a monthly basis. 😄 