### PR TITLE
ci: run `npm ci` to install and ignore scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - run: npm install
+      - run: npm ci --ignore-scripts
       - run: npm run lint
       - run: npm test -- --ci --coverage
   release:
@@ -42,7 +42,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - run: npm install
+      - run: npm ci --ignore-scripts
       - name: Configure git user
         run: |
           git config user.email 'github-action@users.noreply.github.com'

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -21,7 +21,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - run: npm install
+      - run: npm ci --ignore-scripts
       - uses: ./
         id: run_commitlint
         env:
@@ -46,7 +46,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - run: npm install
+      - run: npm ci --ignore-scripts
       - uses: ./
         env:
           NODE_PATH: ${{ github.workspace }}/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk --no-cache add git
 
 COPY package*.json /
 
-RUN npm ci --production
+RUN npm ci --production --ignore-scripts
 
 COPY . .
 


### PR DESCRIPTION
`npm ci` is meant to be used in CI environments and the scripts are ignored to prevent e.g. Husky
from being installed in the CI environment. See https://docs.npmjs.com/cli/v7/commands/npm-ci.