### PR TITLE
Add specific permissions to workflows under .github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on: [push]
 
 jobs:
   sanity-checks:
+    permissions:
+      contents: read
     name: Sanity Checks
     runs-on: ubuntu-latest
     steps:
@@ -22,6 +24,8 @@ jobs:
       - run: npm run lint
       - run: npm test -- --ci --coverage
   release:
+    permissions:
+      contents: write
     needs: sanity-checks
     runs-on: ubuntu-latest
     if: "github.ref == 'refs/heads/master' && !contains(toJSON(github.event.commits.*.message), '[skip-ci]')"


### PR DESCRIPTION
This PR adds specific permissions to the existing ci.yml workflow under .github/workflows.

### Background

I am the founder of [Step Security](https://www.stepsecurity.io), and have implemented a [GitHub App](https://github.com/apps/step-security) to automatically restrict permissions for the GITHUB_TOKEN in workflows. This is a security best practice as per the GitHub Actions [hardening guide](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions). 

I am trying the App out on important public repositories, by forking them, installing the App on the fork, and manually creating PRs with the fixed workflows. The App automatically fixes permissions when a new PR is created that changes  a workflow, so feel free to install it for future workflows, or try it out on other repos. It will stay free for public repos...

I have manually reviewed the changes, and they do look good to me. If something looks off, please let me know. If you have feedback, would love to hear it. Unfortunately, the other workflow could not be fixed, since it uses your action as a local action (./) which is not supported as of now. Thanks!