### PR TITLE
feat: use configurable dockerRepoURL when present as action input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [4.1.9](https://github.com/wagoid/commitlint-github-action/compare/v4.1.8...v4.1.9) (2021-10-11)
+### [4.1.10](https://github.com/wagoid/commitlint-github-action/compare/v4.1.9...v4.1.10) (2022-01-28)
 
+### Features
+
+- support for passing custom Docker repository URL as input to the action ([d6d6fc0](https://github.com/wagoid/commitlint-github-action/commit/d6d6fc0ae0ec45f7b495ae44a78ec5499877ae0d)))
+
+### [4.1.9](https://github.com/wagoid/commitlint-github-action/compare/v4.1.8...v4.1.9) (2021-10-11)
 
 ### Bug Fixes
 
-* use helpUrl from config when present ([6f0b49b](https://github.com/wagoid/commitlint-github-action/commit/6f0b49bb7b70977c2f0ea471a0282d21d5a8aab5)), closes [#234](https://github.com/wagoid/commitlint-github-action/issues/234)
+- use helpUrl from config when present ([6f0b49b](https://github.com/wagoid/commitlint-github-action/commit/6f0b49bb7b70977c2f0ea471a0282d21d5a8aab5)), closes [#234](https://github.com/wagoid/commitlint-github-action/issues/234)
 
 ### [4.1.8](https://github.com/wagoid/commitlint-github-action/compare/v4.1.7...v4.1.8) (2021-10-11)
 
@@ -21,11 +26,10 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### [4.1.3](https://github.com/wagoid/commitlint-github-action/compare/v4.1.2...v4.1.3) (2021-09-11)
 
-
 ### Bug Fixes
 
-* action failing to check footer of a single commit ([961b6d4](https://github.com/wagoid/commitlint-github-action/commit/961b6d4cd7565e86ea5e28bcb015042ae2022f4f)), closes [#187](https://github.com/wagoid/commitlint-github-action/issues/187)
-* vulnerabilities from npm audit ([bf83d2b](https://github.com/wagoid/commitlint-github-action/commit/bf83d2b35c4177779d047f464b48d9907f2c5201))
+- action failing to check footer of a single commit ([961b6d4](https://github.com/wagoid/commitlint-github-action/commit/961b6d4cd7565e86ea5e28bcb015042ae2022f4f)), closes [#187](https://github.com/wagoid/commitlint-github-action/issues/187)
+- vulnerabilities from npm audit ([bf83d2b](https://github.com/wagoid/commitlint-github-action/commit/bf83d2b35c4177779d047f464b48d9907f2c5201))
 
 ### [4.1.2](https://github.com/wagoid/commitlint-github-action/compare/v4.1.1...v4.1.2) (2021-09-11)
 
@@ -33,39 +37,35 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [4.1.0](https://github.com/wagoid/commitlint-github-action/compare/v4.0.3...v4.1.0) (2021-07-17)
 
-
 ### Features
 
-* officially support commitlint-plugin-function-rules ([d6d6fc0](https://github.com/wagoid/commitlint-github-action/commit/d6d6fc0ae0ec45f7b495ae44a78ec5499877ae0d)), closes [#196](https://github.com/wagoid/commitlint-github-action/issues/196)
+- officially support commitlint-plugin-function-rules ([d6d6fc0](https://github.com/wagoid/commitlint-github-action/commit/d6d6fc0ae0ec45f7b495ae44a78ec5499877ae0d)), closes [#196](https://github.com/wagoid/commitlint-github-action/issues/196)
 
 ### [4.0.3](https://github.com/wagoid/commitlint-github-action/compare/v4.0.2...v4.0.3) (2021-07-17)
 
-
 ### Bug Fixes
 
-* build the action with rollup ([2e57812](https://github.com/wagoid/commitlint-github-action/commit/2e578124a54b446aaf8dfa6d7c71d92e2d6a3de7)), closes [#194](https://github.com/wagoid/commitlint-github-action/issues/194)
+- build the action with rollup ([2e57812](https://github.com/wagoid/commitlint-github-action/commit/2e578124a54b446aaf8dfa6d7c71d92e2d6a3de7)), closes [#194](https://github.com/wagoid/commitlint-github-action/issues/194)
 
 ### [4.0.2](https://github.com/wagoid/commitlint-github-action/compare/v4.0.1...v4.0.2) (2021-07-15)
 
-
 ### Bug Fixes
 
-* default to .cjs extension in config files ([5b6cd1b](https://github.com/wagoid/commitlint-github-action/commit/5b6cd1b23af3fcd4e6df552d48cc01dff41262dd))
+- default to .cjs extension in config files ([5b6cd1b](https://github.com/wagoid/commitlint-github-action/commit/5b6cd1b23af3fcd4e6df552d48cc01dff41262dd))
 
 ### [4.0.1](https://github.com/wagoid/commitlint-github-action/compare/v4.0.0...v4.0.1) (2021-07-15)
 
 ## [4.0.0](https://github.com/wagoid/commitlint-github-action/compare/v3.1.4...v4.0.0) (2021-07-15)
 
-
 ### ⚠ BREAKING CHANGES
 
-* Node.js version used on the action updated from 12 to
-16
+- Node.js version used on the action updated from 12 to
+  16
 
 ### Features
 
-* update dependencies that needed to switch to ESM syntax ([5463926](https://github.com/wagoid/commitlint-github-action/commit/5463926c07584c419d865a3fc9efdb382be54995))
-* upgrade to node.js 16 to support ES modules by default ([30d514f](https://github.com/wagoid/commitlint-github-action/commit/30d514f252505053d2e65896a0865ff0302b7233))
+- update dependencies that needed to switch to ESM syntax ([5463926](https://github.com/wagoid/commitlint-github-action/commit/5463926c07584c419d865a3fc9efdb382be54995))
+- upgrade to node.js 16 to support ES modules by default ([30d514f](https://github.com/wagoid/commitlint-github-action/commit/30d514f252505053d2e65896a0865ff0302b7233))
 
 ### [3.1.4](https://github.com/wagoid/commitlint-github-action/compare/v3.1.3...v3.1.4) (2021-05-19)
 
@@ -77,10 +77,9 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [3.1.0](https://github.com/wagoid/commitlint-github-action/compare/v3.0.8...v3.1.0) (2021-04-06)
 
-
 ### Features
 
-* add support for pull_request_target event ([de51303](https://github.com/wagoid/commitlint-github-action/commit/de513030467551ee03fb8827bd790967fd5818ab))
+- add support for pull_request_target event ([de51303](https://github.com/wagoid/commitlint-github-action/commit/de513030467551ee03fb8827bd790967fd5818ab))
 
 ### [3.0.8](https://github.com/wagoid/commitlint-github-action/compare/v3.0.7...v3.0.8) (2021-04-05)
 
@@ -88,10 +87,9 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### [3.0.6](https://github.com/wagoid/commitlint-github-action/compare/v3.0.5...v3.0.6) (2021-03-02)
 
-
 ### Bug Fixes
 
-* perform an atomic push when releasing ([9d00d1e](https://github.com/wagoid/commitlint-github-action/commit/9d00d1e75718143215dbf95c9c12956c56225e90))
+- perform an atomic push when releasing ([9d00d1e](https://github.com/wagoid/commitlint-github-action/commit/9d00d1e75718143215dbf95c9c12956c56225e90))
 
 ### [3.0.5](https://github.com/wagoid/commitlint-github-action/compare/v3.0.3...v3.0.5) (2021-03-02)
 
@@ -105,24 +103,22 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [3.0.0](https://github.com/wagoid/commitlint-github-action/compare/v2.2.5...v3.0.0) (2021-02-24)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **deps:** Remove support for lerna v2 and change the order of the `extends` resolution
-from right-to-left to left-to-right.
+- **deps:** Remove support for lerna v2 and change the order of the `extends` resolution
+  from right-to-left to left-to-right.
 
 ### Bug Fixes
 
-* **deps:** udpate commitlint monorepo to v12 ([8b0b095](https://github.com/wagoid/commitlint-github-action/commit/8b0b095f5e2c4a8bc5ebc94da6e1a9c0ebc6b862)), closes [#97](https://github.com/wagoid/commitlint-github-action/issues/97)
+- **deps:** udpate commitlint monorepo to v12 ([8b0b095](https://github.com/wagoid/commitlint-github-action/commit/8b0b095f5e2c4a8bc5ebc94da6e1a9c0ebc6b862)), closes [#97](https://github.com/wagoid/commitlint-github-action/issues/97)
 
 ### [2.2.5](https://github.com/wagoid/commitlint-github-action/compare/v2.2.4...v2.2.5) (2021-02-18)
 
 ### [2.2.4](https://github.com/wagoid/commitlint-github-action/compare/v2.2.3...v2.2.4) (2021-02-17)
 
-
 ### Bug Fixes
 
-* call getOctokit function instead of removed Github constructor ([84dd768](https://github.com/wagoid/commitlint-github-action/commit/84dd7685c6e51c38415801f8ca57df0578a83059))
+- call getOctokit function instead of removed Github constructor ([84dd768](https://github.com/wagoid/commitlint-github-action/commit/84dd7685c6e51c38415801f8ca57df0578a83059))
 
 ### [2.2.3](https://github.com/wagoid/commitlint-github-action/compare/v2.2.2...v2.2.3) (2021-02-15)
 
@@ -132,18 +128,16 @@ from right-to-left to left-to-right.
 
 ## [2.2.0](https://github.com/wagoid/commitlint-github-action/compare/v2.1.7...v2.2.0) (2021-02-07)
 
-
 ### Features
 
-* add outputs generation again ([a34ac47](https://github.com/wagoid/commitlint-github-action/commit/a34ac47c340ba0062e19bae66271eef6390ab03e)), closes [/github.com/actions/toolkit/issues/702#issuecomment-774269650](https://github.com/wagoid//github.com/actions/toolkit/issues/702/issues/issuecomment-774269650)
+- add outputs generation again ([a34ac47](https://github.com/wagoid/commitlint-github-action/commit/a34ac47c340ba0062e19bae66271eef6390ab03e)), closes [/github.com/actions/toolkit/issues/702#issuecomment-774269650](https://github.com/wagoid//github.com/actions/toolkit/issues/702/issues/issuecomment-774269650)
 
 ### [2.1.7](https://github.com/wagoid/commitlint-github-action/compare/v2.1.6...v2.1.7) (2021-01-28)
 
-
 ### Bug Fixes
 
-* remove output generation ([b674cd3](https://github.com/wagoid/commitlint-github-action/commit/b674cd3ec44b3d627899d44e7cd5c649566d291a))
-* stop trying to issue commands on failures ([1128358](https://github.com/wagoid/commitlint-github-action/commit/1128358de33626153faadc9d01d0fad8bde5cfb8)), closes [#70](https://github.com/wagoid/commitlint-github-action/issues/70)
+- remove output generation ([b674cd3](https://github.com/wagoid/commitlint-github-action/commit/b674cd3ec44b3d627899d44e7cd5c649566d291a))
+- stop trying to issue commands on failures ([1128358](https://github.com/wagoid/commitlint-github-action/commit/1128358de33626153faadc9d01d0fad8bde5cfb8)), closes [#70](https://github.com/wagoid/commitlint-github-action/issues/70)
 
 ### [2.1.6](https://github.com/wagoid/commitlint-github-action/compare/v2.1.5...v2.1.6) (2020-12-16)
 
@@ -157,17 +151,15 @@ from right-to-left to left-to-right.
 
 ### [2.1.1](https://github.com/wagoid/commitlint-github-action/compare/v2.1.0...v2.1.1) (2020-11-11)
 
-
 ### Bug Fixes
 
-* do not run workflow commands in commit messages ([d67c2ec](https://github.com/wagoid/commitlint-github-action/commit/d67c2ec96c0039c3cdbde4e677be13127062ed85))
+- do not run workflow commands in commit messages ([d67c2ec](https://github.com/wagoid/commitlint-github-action/commit/d67c2ec96c0039c3cdbde4e677be13127062ed85))
 
 ## [2.1.0](https://github.com/wagoid/commitlint-github-action/compare/v2.0.5...v2.1.0) (2020-09-14)
 
-
 ### Features
 
-* upgrade dependencies to their latest version ([f162ac0](https://github.com/wagoid/commitlint-github-action/commit/f162ac07f904e8b5578fa77172b997145fd61b7a))
+- upgrade dependencies to their latest version ([f162ac0](https://github.com/wagoid/commitlint-github-action/commit/f162ac07f904e8b5578fa77172b997145fd61b7a))
 
 ### 2.0.5 (2020-09-14)
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ You can see more info about GitHub's default token [here](https://docs.github.co
 
 default: `${{ github.token }}`
 
+### `dockerImage`
+
+Docker repository to be used by the action. Useful when using a private repository as a pull though cache for images from Docker Hub to avoid rate-limitting (read more [here](https://www.docker.com/increase-rate-limits)).
+Note that this can also be achieved by setting up a Docker Hub repository mirror on the runner, as described [here](https://docs.docker.com/registry/recipes/mirror/).
+By default, uses an image hosted in a public Docker Hub registry [here](https://hub.docker.com/r/wagoid/commitlint-github-action).
+
+default: `docker://wagoid/commitlint-github-action`
+
 ## Outputs
 
 ### `results`

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,8 @@ description: Lints Pull Request commit messages with commitlint
 author: Wagner Santos
 inputs:
   configFile:
-    description: Commitlint config file. If the file doesn't exist, config-conventional settings will be
+    description:
+      Commitlint config file. If the file doesn't exist, config-conventional settings will be
       loaded as a fallback.
     default: ./commitlint.config.js
     required: false
@@ -11,11 +12,11 @@ inputs:
     description: >
       When set to true, we follow only the first parent commit when seeing a merge commit. More info
       in git-log docs https://git-scm.com/docs/git-log#Documentation/git-log.txt---first-parent
-    default: "true"
+    default: 'true'
     required: false
   failOnWarnings:
     description: Whether you want to fail on warnings or not
-    default: "false"
+    default: 'false'
     required: false
   helpURL:
     description: Link to a page explaining your commit message convention
@@ -28,12 +29,16 @@ inputs:
       https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token
     default: ${{ github.token }}
     required: false
+  dockerRepoURL:
+    description: Docker repository URL to be used by the action. Useful when using a private repository mirror instead of public Docker Hub.
+    default: docker://wagoid/commitlint-github-action
+    required: false
 outputs:
   results:
     description: The error and warning messages for each one of the analyzed commits
 runs:
   using: docker
-  image: docker://wagoid/commitlint-github-action:4.1.9
+  image: '${{ inputs.dockerRepoURL }}:4.1.10'
 branding:
   icon: check-square
   color: blue

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "commitlint-github-action",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "4.1.9",
+      "name": "commitlint-github-action",
+      "version": "4.1.10",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlint-github-action",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "description": "commitlint github action",
   "private": true,
   "main": "./dist/run.js",


### PR DESCRIPTION
Make Docker repository URL configurable to allow clients to
choose different repository URL for the action, in case they
don't have access to changing Docker configuration on their
runners.