### PR TITLE
build: upgrade base Docker image to prevent security vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.5.0-alpine3.14 as build
+FROM node:16.14.2-alpine3.14 as build
 
 COPY package*.json /
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "yaml": "^2.0.1"
       },
       "engines": {
-        "node": "16.5.0"
+        "node": "v16.14.2"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "rollup -c"
   },
   "engines": {
-    "node": "16.5.0"
+    "node": "v16.14.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
According to Snyk.io, the currently used base Docker image has 19 security
vulnerabilities (13 high).
https://snyk.io/test/docker/node%3A16.5.0-alpine3.14

On the other hand, the image `node:16.14.2-alpine3.14` has no known security
vulnerabilies.

https://snyk.io/test/docker/node%3A16.14.2-alpine3.14

This commit upgrades the image to fix the above mentioned issues.