### PR TITLE
ci: set workspace directory as safe after checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v4
@@ -134,7 +134,7 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v2

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,4 +8,8 @@ else
   export NODE_PATH=$NODE_PATH:/node_modules
 fi
 
+# Since actions/checkout can be setup with a different user ID, we need to set the workspace as safe inside this action
+# Info about the vunlerability: https://github.blog/2022-04-12-git-security-vulnerability-announced/
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
 node /run.js


### PR DESCRIPTION
Related to https://github.com/actions/checkout/issues/760

`actions/checkout` already fixed the issue on their side in
 [v3.0.1](https://github.com/actions/checkout/releases/tag/v3.0.1).
 But since this is a container action, it can be run with another uid than the one
 from `actions/checkout` and therefore we need to add the `safe.directory` config again.

Another way of fixing this would be to make this action run with the same uid as the github runner, but as mentioned [here](https://github.com/actions/checkout/issues/760#issuecomment-1098135955) we're not sure whether the `1000` uid of the runner is reliable.

The different `uid` issue seems more like a Github Actions ecosystem problem, maybe they'll take care of it later.