### PR TITLE
fix: update isDepsCommit to accept `build` type

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -6,7 +6,7 @@ const bodyMaxLineLength = 100
 const validateBodyMaxLengthIgnoringDeps = (parsedCommit) => {
   const { type, scope, body } = parsedCommit
   const isDepsCommit =
-    type === 'chore' && (scope === 'deps' || scope === 'deps-dev')
+    ['chore', 'build'].includes(type) && ['deps', 'deps-dev'].includes(scope)
 
   return [
     isDepsCommit || !body || maxLineLength(body, bodyMaxLineLength),


### PR DESCRIPTION
fixes #439 with further explanation on issue https://github.com/wagoid/commitlint-github-action/issues/439#issuecomment-1152690249