### PR TITLE
feat: adds commitDepth as new input param

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Link to a page explaining your commit message convention.
 
 default: `https://github.com/conventional-changelog/commitlint/#what-is-commitlint`
 
+### `commitDepth`
+
+When set to a valid Integer value - X, considers only the latest X number of commits.
+
+default: `null` (Equivalent to linting all commits)
+
 ### `token`
 
 Personal access token (PAT) used to interact with the GitHub API.
@@ -144,6 +150,10 @@ jobs:
       # Run the commitlint action, considering its own dependencies and yours as well 🚀
       # `github.workspace` is the path to your repository.
       - uses: wagoid/commitlint-github-action@v5
+        # Optinally, add a commitDepth parameter
+        # This example would only consider the last 10 commits.
+        with:
+          commitDepth: 10
         env:
           NODE_PATH: ${{ github.workspace }}/node_modules
 ```

--- a/README.md
+++ b/README.md
@@ -150,10 +150,6 @@ jobs:
       # Run the commitlint action, considering its own dependencies and yours as well 🚀
       # `github.workspace` is the path to your repository.
       - uses: wagoid/commitlint-github-action@v5
-        # Optinally, add a commitDepth parameter
-        # This example would only consider the last 10 commits.
-        with:
-          commitDepth: 10
         env:
           NODE_PATH: ${{ github.workspace }}/node_modules
 ```

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,8 @@ description: Lints Pull Request commit messages with commitlint
 author: Wagner Santos
 inputs:
   configFile:
-    description: Commitlint config file. If the file doesn't exist, config-conventional settings will be
+    description:
+      Commitlint config file. If the file doesn't exist, config-conventional settings will be
       loaded as a fallback.
     default: ./commitlint.config.js
     required: false
@@ -12,15 +13,19 @@ inputs:
       When set to true, we follow only the first parent commit when seeing a merge commit.
       More info in git-log docs
       https://git-scm.com/docs/git-log#Documentation/git-log.txt---first-parent
-    default: "true"
+    default: 'true'
     required: false
   failOnWarnings:
     description: Whether you want to fail on warnings or not
-    default: "false"
+    default: 'false'
     required: false
   helpURL:
     description: Link to a page explaining your commit message convention
     default: https://github.com/conventional-changelog/commitlint/#what-is-commitlint
+    required: false
+  commitDepth:
+    description: When set to a valid Integer value - X, considers only the latest X number of commits.
+    default: ''
     required: false
   token:
     description: >


### PR DESCRIPTION
* adds a new optional commitDepth parameter. 
When set to a valid Integer value - X, considers only the latest X number of commits.


This stems from a discussion around https://github.com/wagoid/commitlint-github-action/issues/363
