### PR TITLE
fix(action): removed unnecessary setOutput call

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ outputs:
     description: The error and warning messages for each one of the analyzed commits
 runs:
   using: docker
-  image: Dockerfile
+  image: docker://wagoid/commitlint-github-action:5.3.1
 branding:
   icon: check-square
   color: blue

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ outputs:
     description: The error and warning messages for each one of the analyzed commits
 runs:
   using: docker
-  image: docker://wagoid/commitlint-github-action:5.3.1
+  image: Dockerfile
 branding:
   icon: check-square
   color: blue

--- a/src/action.js
+++ b/src/action.js
@@ -1,6 +1,6 @@
 import { existsSync } from 'fs'
 import { resolve } from 'path'
-import { getInput, setFailed, setOutput } from '@actions/core'
+import { getInput, setFailed } from '@actions/core'
 import { context as eventContext, getOctokit } from '@actions/github'
 import lint from '@commitlint/lint'
 import { format } from '@commitlint/format'
@@ -150,7 +150,7 @@ const showLintResults = async ([from, to]) => {
     // this would be a good place to implement the setNeutral() when it's eventually implimented.
     // for now it can pass with a check mark.
     console.log('Passing despite errors ✅')
-    setOutput(`You have commit messages with errors\n\n${formattedResults}`)
+    console.log(formattedResults)
   } else if (formattedResults) {
     setFailedAction(formattedResults)
   } else {

--- a/src/action.js
+++ b/src/action.js
@@ -150,7 +150,7 @@ const showLintResults = async ([from, to]) => {
     // this would be a good place to implement the setNeutral() when it's eventually implimented.
     // for now it can pass with a check mark.
     console.log(formattedResults)
-    console.log('Passing despite errors ✅')
+    console.log('Fail on Errors is set to false: Passing despite errors ✅')
   } else if (formattedResults) {
     setFailedAction(formattedResults)
   } else {

--- a/src/action.js
+++ b/src/action.js
@@ -149,8 +149,8 @@ const showLintResults = async ([from, to]) => {
     // https://github.com/actions/toolkit/tree/master/packages/core#exit-codes
     // this would be a good place to implement the setNeutral() when it's eventually implimented.
     // for now it can pass with a check mark.
-    console.log('Passing despite errors ✅')
     console.log(formattedResults)
+    console.log('Passing despite errors ✅')
   } else if (formattedResults) {
     setFailedAction(formattedResults)
   } else {

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -109,8 +109,6 @@ describe('Commit Linter action', () => {
     td.replace(process, 'cwd', () => cwd)
 
     await runAction()
-
-    console.log()
     td.verify(core.setFailed(contains('wrong message 1')))
     td.verify(core.setFailed(contains('wrong message 2')))
   })

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -128,9 +128,9 @@ describe('Commit Linter action', () => {
     await runAction()
 
     td.verify(core.setFailed(), { times: 0, ignoreExtraArgs: true })
+    td.verify(console.log(contains('wrong message 1')))
+    td.verify(console.log(contains('wrong message 2')))
     td.verify(console.log(contains('Passing despite errors ✅')))
-    td.verify(core.setOutput(contains('wrong message 1')))
-    td.verify(core.setOutput(contains('wrong message 2')))
   })
 
   it('should pass for push range with correct messages with failOnErrors set to false', async () => {


### PR DESCRIPTION
I was hitting an issue with the action reporting:
```
Error: Unable to process file command 'output' successfully.
Error: Invalid format 'You have commit messages with errors
```
I looked into it and the setOutput() call was formatted wrong. I actually read through the action code again and realized the `generateOutputs.js` file was already setting that `results` output so my call to the core function was unnecessary. I removed it and updated the tests accordingly.  