### PR TITLE
fix: upgrade commitlint to latest v18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,14 @@
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@actions/github": "^6.0.0",
-        "@commitlint/config-angular": "^18.1.0",
-        "@commitlint/config-conventional": "^18.1.0",
-        "@commitlint/config-lerna-scopes": "^18.1.0",
-        "@commitlint/config-patternplate": "^18.1.0",
-        "@commitlint/ensure": "^18.1.0",
-        "@commitlint/format": "^18.1.0",
-        "@commitlint/lint": "^18.1.0",
-        "@commitlint/load": "^18.2.0",
+        "@commitlint/config-angular": "^18.6.1",
+        "@commitlint/config-conventional": "^18.6.3",
+        "@commitlint/config-lerna-scopes": "^18.6.1",
+        "@commitlint/config-patternplate": "^18.6.1",
+        "@commitlint/ensure": "^18.6.1",
+        "@commitlint/format": "^18.6.1",
+        "@commitlint/lint": "^18.6.1",
+        "@commitlint/load": "^18.6.1",
         "commitlint-config-jira": "^1.6.4",
         "commitlint-plugin-function-rules": "^2.0.2",
         "commitlint-plugin-jira-rules": "^1.6.4",
@@ -31,7 +31,7 @@
       "devDependencies": {
         "@babel/core": "^7.19.3",
         "@babel/preset-env": "^7.19.3",
-        "@commitlint/cli": "^18.2.0",
+        "@commitlint/cli": "^18.6.1",
         "@commitlint/test": "^9.0.1",
         "@commitlint/test-environment": "^9.0.1",
         "@jest/globals": "^29.4.2",
@@ -2024,16 +2024,16 @@
       "dev": true
     },
     "node_modules/@commitlint/cli": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-18.2.0.tgz",
-      "integrity": "sha512-F/DCG791kMFmWg5eIdogakuGeg4OiI2kD430ed1a1Hh3epvrJdeIAgcGADAMIOmF+m0S1+VlIYUKG2dvQQ1Izw==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-18.6.1.tgz",
+      "integrity": "sha512-5IDE0a+lWGdkOvKH892HHAZgbAjcj1mT5QrfA/SVbLJV/BbBMGyKN0W5mhgjekPJJwEQdVNvhl9PwUacY58Usw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/format": "^18.1.0",
-        "@commitlint/lint": "^18.1.0",
-        "@commitlint/load": "^18.2.0",
-        "@commitlint/read": "^18.1.0",
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/format": "^18.6.1",
+        "@commitlint/lint": "^18.6.1",
+        "@commitlint/load": "^18.6.1",
+        "@commitlint/read": "^18.6.1",
+        "@commitlint/types": "^18.6.1",
         "execa": "^5.0.0",
         "lodash.isfunction": "^3.0.9",
         "resolve-from": "5.0.0",
@@ -2047,48 +2047,72 @@
         "node": ">=v18"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/yargs": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
-      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+    "node_modules/@commitlint/cli/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
         "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
-    "node_modules/@commitlint/config-angular": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-angular/-/config-angular-18.1.0.tgz",
-      "integrity": "sha512-K6uIRvTamwqT/XtPGLLCpOhTFb5X2iTmu7JCgqgAZZUwYjvCMiJD35lr4Tul3A6ZK/F9cSc0rhCwU5cwfvhLzA==",
+    "node_modules/@commitlint/cli/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "dependencies": {
-        "@commitlint/config-angular-type-enum": "^18.1.0"
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@commitlint/config-angular": {
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-angular/-/config-angular-18.6.1.tgz",
+      "integrity": "sha512-Aki/xnNPc36bo47gkD/BIgR+vWAik/9k3l+9I46K3UlZadcE1XqqrEPkFWwhGHEGb4X3571IUbJZM33qXuSIcw==",
+      "dependencies": {
+        "@commitlint/config-angular-type-enum": "^18.6.1"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/config-angular-type-enum": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-angular-type-enum/-/config-angular-type-enum-18.1.0.tgz",
-      "integrity": "sha512-bt6GntMXnWbF2uuWRfjrksZGhHm3egW+F1BB1MzWXLXdyWsfpdwsY/hDIcfvjWqMV52fYNI6So4N6zu7nKNopQ==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-angular-type-enum/-/config-angular-type-enum-18.6.1.tgz",
+      "integrity": "sha512-qX9MdNJ82I5nKY7zD20Mo6Oz8Qx1cBhoet+ZI7ItWdhKAzp9jY2HTg40sLM2zxGrd1pHZCot6MXXKaBHr7bU9A==",
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-18.1.0.tgz",
-      "integrity": "sha512-8vvvtV3GOLEMHeKc8PjRL1lfP1Y4B6BG0WroFd9PJeRiOc3nFX1J0wlJenLURzl9Qus6YXVGWf+a/ZlbCKT3AA==",
+      "version": "18.6.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-18.6.3.tgz",
+      "integrity": "sha512-8ZrRHqF6je+TRaFoJVwszwnOXb/VeYrPmTwPhf0WxpzpGTcYy1p0SPyZ2eRn/sRi/obnWAcobtDAq6+gJQQNhQ==",
       "dependencies": {
+        "@commitlint/types": "^18.6.1",
         "conventional-changelog-conventionalcommits": "^7.0.2"
       },
       "engines": {
@@ -2096,14 +2120,14 @@
       }
     },
     "node_modules/@commitlint/config-lerna-scopes": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-lerna-scopes/-/config-lerna-scopes-18.1.0.tgz",
-      "integrity": "sha512-zspQlWU/qqg3cwrPhEJ9Me1Mmr78OLTmqBk2gJPW71j/xlatHy/imxmbjwqJEldd6LBvcXKQRxEM2n8jNMdn7A==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-lerna-scopes/-/config-lerna-scopes-18.6.1.tgz",
+      "integrity": "sha512-61wMcaSekEIXnbOfcA1QuF4EtU76wTtUHHdWQj9YoyoYRQtscth6l9jTql/vkCQ+bVAwWDfcJhLRksNNe+1U/w==",
       "dependencies": {
         "@lerna/project": "^6.0.0",
         "glob": "^8.0.3",
         "import-from": "4.0.0",
-        "semver": "7.5.4"
+        "semver": "7.6.0"
       },
       "engines": {
         "node": ">=v18"
@@ -2256,11 +2280,11 @@
       }
     },
     "node_modules/@commitlint/config-patternplate": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-patternplate/-/config-patternplate-18.1.0.tgz",
-      "integrity": "sha512-k2pbRnPwoLAqDURiS92f/WJuD34QJBMt9fEnA+/tnk6BPqD51twrv/PChkWZK8oJiAQghsDUezCPPSC+EjY23A==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-patternplate/-/config-patternplate-18.6.1.tgz",
+      "integrity": "sha512-TwyUOImKi6fglV+OX9wwdezei08NjHw7GZRUqSflQuZ/9BLaECNL1ks9j/th14Y5PWdzZmqjN9pfp87Js9DsJA==",
       "dependencies": {
-        "@commitlint/config-angular": "^18.1.0",
+        "@commitlint/config-angular": "^18.6.1",
         "glob": "^8.0.3",
         "lodash.merge": "^4.6.2"
       },
@@ -2306,11 +2330,11 @@
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-18.1.0.tgz",
-      "integrity": "sha512-kbHkIuItXn93o2NmTdwi5Mk1ujyuSIysRE/XHtrcps/27GuUKEIqBJp6TdJ4Sq+ze59RlzYSHMKuDKZbfg9+uQ==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-18.6.1.tgz",
+      "integrity": "sha512-05uiToBVfPhepcQWE1ZQBR/Io3+tb3gEotZjnI4tTzzPk16NffN6YABgwFQCLmzZefbDcmwWqJWc2XT47q7Znw==",
       "dependencies": {
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/types": "^18.6.1",
         "ajv": "^8.11.0"
       },
       "engines": {
@@ -2338,11 +2362,11 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@commitlint/ensure": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-18.1.0.tgz",
-      "integrity": "sha512-CkPzJ9UBumIo54VDcpmBlaVX81J++wzEhN3DJH9+6PaLeiIG+gkSx8t7C2gfwG7PaiW4HzQtdQlBN5ab+c4vFQ==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-18.6.1.tgz",
+      "integrity": "sha512-BPm6+SspyxQ7ZTsZwXc7TRQL5kh5YWt3euKmEIBZnocMFkJevqs3fbLRb8+8I/cfbVcAo4mxRlpTPfz8zX7SnQ==",
       "dependencies": {
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/types": "^18.6.1",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.snakecase": "^4.1.1",
@@ -2354,19 +2378,19 @@
       }
     },
     "node_modules/@commitlint/execute-rule": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-18.1.0.tgz",
-      "integrity": "sha512-w3Vt4K+O7+nSr9/gFSEfZ1exKUOPSlJaRpnk7Y+XowEhvwT7AIk1HNANH+gETf0zGZ020+hfiMW/Ome+SNCUsg==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-18.6.1.tgz",
+      "integrity": "sha512-7s37a+iWyJiGUeMFF6qBlyZciUkF8odSAnHijbD36YDctLhGKoYltdvuJ/AFfRm6cBLRtRk9cCVPdsEFtt/2rg==",
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-18.1.0.tgz",
-      "integrity": "sha512-So/w217tGWMZZb1yXcUFNF2qFLyYtSVqbnGoMbX8a+JKcG4oB11Gc1adS0ssUOMivtiNpaLtkSHFynyiwtJtiQ==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-18.6.1.tgz",
+      "integrity": "sha512-K8mNcfU/JEFCharj2xVjxGSF+My+FbUHoqR+4GqPGrHNqXOGNio47ziiR4HQUPKtiNs05o8/WyLBoIpMVOP7wg==",
       "dependencies": {
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/types": "^18.6.1",
         "chalk": "^4.1.0"
       },
       "engines": {
@@ -2374,43 +2398,42 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-18.1.0.tgz",
-      "integrity": "sha512-fa1fY93J/Nx2GH6r6WOLdBOiL7x9Uc1N7wcpmaJ1C5Qs6P+rPSUTkofe2IOhSJIJoboHfAH6W0ru4xtK689t0Q==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-18.6.1.tgz",
+      "integrity": "sha512-MOfJjkEJj/wOaPBw5jFjTtfnx72RGwqYIROABudOtJKW7isVjFe9j0t8xhceA02QebtYf4P/zea4HIwnXg8rvA==",
       "dependencies": {
-        "@commitlint/types": "^18.1.0",
-        "semver": "7.5.4"
+        "@commitlint/types": "^18.6.1",
+        "semver": "7.6.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-18.1.0.tgz",
-      "integrity": "sha512-LGB3eI5UYu5LLayibNrRM4bSbowr1z9uyqvp0c7+0KaSJi+xHxy/QEhb6fy4bMAtbXEvygY0sUu9HxSWg41rVQ==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-18.6.1.tgz",
+      "integrity": "sha512-8WwIFo3jAuU+h1PkYe5SfnIOzp+TtBHpFr4S8oJWhu44IWKuVx6GOPux3+9H1iHOan/rGBaiacicZkMZuluhfQ==",
       "dependencies": {
-        "@commitlint/is-ignored": "^18.1.0",
-        "@commitlint/parse": "^18.1.0",
-        "@commitlint/rules": "^18.1.0",
-        "@commitlint/types": "^18.1.0"
+        "@commitlint/is-ignored": "^18.6.1",
+        "@commitlint/parse": "^18.6.1",
+        "@commitlint/rules": "^18.6.1",
+        "@commitlint/types": "^18.6.1"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-18.2.0.tgz",
-      "integrity": "sha512-xjX3d3CRlOALwImhOsmLYZh14/+gW/KxsY7+bPKrzmGuFailf9K7ckhB071oYZVJdACnpY4hDYiosFyOC+MpAA==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-18.6.1.tgz",
+      "integrity": "sha512-p26x8734tSXUHoAw0ERIiHyW4RaI4Bj99D8YgUlVV9SedLf8hlWAfyIFhHRIhfPngLlCe0QYOdRKYFt8gy56TA==",
       "dependencies": {
-        "@commitlint/config-validator": "^18.1.0",
-        "@commitlint/execute-rule": "^18.1.0",
-        "@commitlint/resolve-extends": "^18.1.0",
-        "@commitlint/types": "^18.1.0",
-        "@types/node": "^18.11.9",
+        "@commitlint/config-validator": "^18.6.1",
+        "@commitlint/execute-rule": "^18.6.1",
+        "@commitlint/resolve-extends": "^18.6.1",
+        "@commitlint/types": "^18.6.1",
         "chalk": "^4.1.0",
-        "cosmiconfig": "^8.0.0",
+        "cosmiconfig": "^8.3.6",
         "cosmiconfig-typescript-loader": "^5.0.0",
         "lodash.isplainobject": "^4.0.6",
         "lodash.merge": "^4.6.2",
@@ -2479,20 +2502,20 @@
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-18.1.0.tgz",
-      "integrity": "sha512-8dT/jJg73wf3o2Mut/fqEDTpBYSIEVtX5PWyuY/0uviEYeheZAczFo/VMIkeGzhJJn1IrcvAwWsvJ1lVGY2I/w==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-18.6.1.tgz",
+      "integrity": "sha512-VKC10UTMLcpVjMIaHHsY1KwhuTQtdIKPkIdVEwWV+YuzKkzhlI3aNy6oo1eAN6b/D2LTtZkJe2enHmX0corYRw==",
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-18.1.0.tgz",
-      "integrity": "sha512-23yv8uBweXWYn8bXk4PjHIsmVA+RkbqPh2h7irupBo2LthVlzMRc4LM6UStasScJ4OlXYYaWOmuP7jcExUF50Q==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-18.6.1.tgz",
+      "integrity": "sha512-eS/3GREtvVJqGZrwAGRwR9Gdno3YcZ6Xvuaa+vUF8j++wsmxrA2En3n0ccfVO2qVOLJC41ni7jSZhQiJpMPGOQ==",
       "dependencies": {
-        "@commitlint/types": "^18.1.0",
-        "conventional-changelog-angular": "^6.0.0",
+        "@commitlint/types": "^18.6.1",
+        "conventional-changelog-angular": "^7.0.0",
         "conventional-commits-parser": "^5.0.0"
       },
       "engines": {
@@ -2500,14 +2523,14 @@
       }
     },
     "node_modules/@commitlint/parse/node_modules/conventional-changelog-angular": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
-      "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
+      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@commitlint/parse/node_modules/conventional-commits-parser": {
@@ -2569,14 +2592,13 @@
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-18.1.0.tgz",
-      "integrity": "sha512-rzfzoKUwxmvYO81tI5o1371Nwt3vhcQR36oTNfupPdU1jgSL3nzBIS3B93LcZh3IYKbCIMyMPN5WZ10BXdeoUg==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-18.6.1.tgz",
+      "integrity": "sha512-ia6ODaQFzXrVul07ffSgbZGFajpe8xhnDeLIprLeyfz3ivQU1dIoHp7yz0QIorZ6yuf4nlzg4ZUkluDrGN/J/w==",
       "dev": true,
       "dependencies": {
-        "@commitlint/top-level": "^18.1.0",
-        "@commitlint/types": "^18.1.0",
-        "fs-extra": "^11.0.0",
+        "@commitlint/top-level": "^18.6.1",
+        "@commitlint/types": "^18.6.1",
         "git-raw-commits": "^2.0.11",
         "minimist": "^1.2.6"
       },
@@ -2584,27 +2606,13 @@
         "node": ">=v18"
       }
     },
-    "node_modules/@commitlint/read/node_modules/fs-extra": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-18.1.0.tgz",
-      "integrity": "sha512-3mZpzOEJkELt7BbaZp6+bofJyxViyObebagFn0A7IHaLARhPkWTivXdjvZHS12nAORftv88Yhbh8eCPKfSvB7g==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-18.6.1.tgz",
+      "integrity": "sha512-ifRAQtHwK+Gj3Bxj/5chhc4L2LIc3s30lpsyW67yyjsETR6ctHAHRu1FSpt0KqahK5xESqoJ92v6XxoDRtjwEQ==",
       "dependencies": {
-        "@commitlint/config-validator": "^18.1.0",
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/config-validator": "^18.6.1",
+        "@commitlint/types": "^18.6.1",
         "import-fresh": "^3.0.0",
         "lodash.mergewith": "^4.6.2",
         "resolve-from": "^5.0.0",
@@ -2615,14 +2623,14 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-18.1.0.tgz",
-      "integrity": "sha512-VJNQ674CRv4znI0DbsjZLVnn647J+BTxHGcrDIsYv7c99gW7TUGeIe5kL80G7l8+5+N0se8v9yn+Prr8xEy6Yw==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-18.6.1.tgz",
+      "integrity": "sha512-kguM6HxZDtz60v/zQYOe0voAtTdGybWXefA1iidjWYmyUUspO1zBPQEmJZ05/plIAqCVyNUTAiRPWIBKLCrGew==",
       "dependencies": {
-        "@commitlint/ensure": "^18.1.0",
-        "@commitlint/message": "^18.1.0",
-        "@commitlint/to-lines": "^18.1.0",
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/ensure": "^18.6.1",
+        "@commitlint/message": "^18.6.1",
+        "@commitlint/to-lines": "^18.6.1",
+        "@commitlint/types": "^18.6.1",
         "execa": "^5.0.0"
       },
       "engines": {
@@ -2747,17 +2755,17 @@
       }
     },
     "node_modules/@commitlint/to-lines": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-18.1.0.tgz",
-      "integrity": "sha512-aHIoSDjG0ckxPLYDpODUeSLbEKmF6Jrs1B5JIssbbE9eemBtXtjm9yzdiAx9ZXcwoHlhbTp2fbndDb3YjlvJag==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-18.6.1.tgz",
+      "integrity": "sha512-Gl+orGBxYSNphx1+83GYeNy5N0dQsHBQ9PJMriaLQDB51UQHCVLBT/HBdOx5VaYksivSf5Os55TLePbRLlW50Q==",
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-18.1.0.tgz",
-      "integrity": "sha512-1/USHlolIxJlsfLKecSXH+6PDojIvnzaJGPYwF7MtnTuuXCNQ4izkeqDsRuNMe9nU2VIKpK9OT8Q412kGNmgGw==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-18.6.1.tgz",
+      "integrity": "sha512-HyiHQZUTf0+r0goTCDs/bbVv/LiiQ7AVtz6KIar+8ZrseB9+YJAIo8HQ2IC2QT1y3N1lbW6OqVEsTHjbT6hGSw==",
       "dev": true,
       "dependencies": {
         "find-up": "^5.0.0"
@@ -2767,9 +2775,9 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-18.1.0.tgz",
-      "integrity": "sha512-65vGxZmbs+2OVwEItxhp3Ul7X2m2LyLfifYI/NdPwRqblmuES2w2aIRhIjb7cwUIBHHSTT8WXj4ixVHQibmvLQ==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-18.6.1.tgz",
+      "integrity": "sha512-gwRLBLra/Dozj2OywopeuHj2ac26gjGkz2cZ+86cTJOdtWfiRRr4+e77ZDAGc6MDWxaWheI+mAV5TLWWRwqrFg==",
       "dependencies": {
         "chalk": "^4.1.0"
       },
@@ -14924,9 +14932,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -17758,16 +17766,16 @@
       "dev": true
     },
     "@commitlint/cli": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-18.2.0.tgz",
-      "integrity": "sha512-F/DCG791kMFmWg5eIdogakuGeg4OiI2kD430ed1a1Hh3epvrJdeIAgcGADAMIOmF+m0S1+VlIYUKG2dvQQ1Izw==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-18.6.1.tgz",
+      "integrity": "sha512-5IDE0a+lWGdkOvKH892HHAZgbAjcj1mT5QrfA/SVbLJV/BbBMGyKN0W5mhgjekPJJwEQdVNvhl9PwUacY58Usw==",
       "dev": true,
       "requires": {
-        "@commitlint/format": "^18.1.0",
-        "@commitlint/lint": "^18.1.0",
-        "@commitlint/load": "^18.2.0",
-        "@commitlint/read": "^18.1.0",
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/format": "^18.6.1",
+        "@commitlint/lint": "^18.6.1",
+        "@commitlint/load": "^18.6.1",
+        "@commitlint/read": "^18.6.1",
+        "@commitlint/types": "^18.6.1",
         "execa": "^5.0.0",
         "lodash.isfunction": "^3.0.9",
         "resolve-from": "5.0.0",
@@ -17775,53 +17783,71 @@
         "yargs": "^17.0.0"
       },
       "dependencies": {
-        "yargs": {
-          "version": "17.1.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
-          "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
           "dev": true,
           "requires": {
-            "cliui": "^7.0.2",
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
             "escalade": "^3.1.1",
             "get-caller-file": "^2.0.5",
             "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
+            "string-width": "^4.2.3",
             "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
+            "yargs-parser": "^21.1.1"
           }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
         }
       }
     },
     "@commitlint/config-angular": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-angular/-/config-angular-18.1.0.tgz",
-      "integrity": "sha512-K6uIRvTamwqT/XtPGLLCpOhTFb5X2iTmu7JCgqgAZZUwYjvCMiJD35lr4Tul3A6ZK/F9cSc0rhCwU5cwfvhLzA==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-angular/-/config-angular-18.6.1.tgz",
+      "integrity": "sha512-Aki/xnNPc36bo47gkD/BIgR+vWAik/9k3l+9I46K3UlZadcE1XqqrEPkFWwhGHEGb4X3571IUbJZM33qXuSIcw==",
       "requires": {
-        "@commitlint/config-angular-type-enum": "^18.1.0"
+        "@commitlint/config-angular-type-enum": "^18.6.1"
       }
     },
     "@commitlint/config-angular-type-enum": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-angular-type-enum/-/config-angular-type-enum-18.1.0.tgz",
-      "integrity": "sha512-bt6GntMXnWbF2uuWRfjrksZGhHm3egW+F1BB1MzWXLXdyWsfpdwsY/hDIcfvjWqMV52fYNI6So4N6zu7nKNopQ=="
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-angular-type-enum/-/config-angular-type-enum-18.6.1.tgz",
+      "integrity": "sha512-qX9MdNJ82I5nKY7zD20Mo6Oz8Qx1cBhoet+ZI7ItWdhKAzp9jY2HTg40sLM2zxGrd1pHZCot6MXXKaBHr7bU9A=="
     },
     "@commitlint/config-conventional": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-18.1.0.tgz",
-      "integrity": "sha512-8vvvtV3GOLEMHeKc8PjRL1lfP1Y4B6BG0WroFd9PJeRiOc3nFX1J0wlJenLURzl9Qus6YXVGWf+a/ZlbCKT3AA==",
+      "version": "18.6.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-18.6.3.tgz",
+      "integrity": "sha512-8ZrRHqF6je+TRaFoJVwszwnOXb/VeYrPmTwPhf0WxpzpGTcYy1p0SPyZ2eRn/sRi/obnWAcobtDAq6+gJQQNhQ==",
       "requires": {
+        "@commitlint/types": "^18.6.1",
         "conventional-changelog-conventionalcommits": "^7.0.2"
       }
     },
     "@commitlint/config-lerna-scopes": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-lerna-scopes/-/config-lerna-scopes-18.1.0.tgz",
-      "integrity": "sha512-zspQlWU/qqg3cwrPhEJ9Me1Mmr78OLTmqBk2gJPW71j/xlatHy/imxmbjwqJEldd6LBvcXKQRxEM2n8jNMdn7A==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-lerna-scopes/-/config-lerna-scopes-18.6.1.tgz",
+      "integrity": "sha512-61wMcaSekEIXnbOfcA1QuF4EtU76wTtUHHdWQj9YoyoYRQtscth6l9jTql/vkCQ+bVAwWDfcJhLRksNNe+1U/w==",
       "requires": {
         "@lerna/project": "^6.0.0",
         "glob": "^8.0.3",
         "import-from": "4.0.0",
-        "semver": "7.5.4"
+        "semver": "7.6.0"
       },
       "dependencies": {
         "@lerna/package": {
@@ -17932,11 +17958,11 @@
       }
     },
     "@commitlint/config-patternplate": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-patternplate/-/config-patternplate-18.1.0.tgz",
-      "integrity": "sha512-k2pbRnPwoLAqDURiS92f/WJuD34QJBMt9fEnA+/tnk6BPqD51twrv/PChkWZK8oJiAQghsDUezCPPSC+EjY23A==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-patternplate/-/config-patternplate-18.6.1.tgz",
+      "integrity": "sha512-TwyUOImKi6fglV+OX9wwdezei08NjHw7GZRUqSflQuZ/9BLaECNL1ks9j/th14Y5PWdzZmqjN9pfp87Js9DsJA==",
       "requires": {
-        "@commitlint/config-angular": "^18.1.0",
+        "@commitlint/config-angular": "^18.6.1",
         "glob": "^8.0.3",
         "lodash.merge": "^4.6.2"
       },
@@ -17972,11 +17998,11 @@
       }
     },
     "@commitlint/config-validator": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-18.1.0.tgz",
-      "integrity": "sha512-kbHkIuItXn93o2NmTdwi5Mk1ujyuSIysRE/XHtrcps/27GuUKEIqBJp6TdJ4Sq+ze59RlzYSHMKuDKZbfg9+uQ==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-18.6.1.tgz",
+      "integrity": "sha512-05uiToBVfPhepcQWE1ZQBR/Io3+tb3gEotZjnI4tTzzPk16NffN6YABgwFQCLmzZefbDcmwWqJWc2XT47q7Znw==",
       "requires": {
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/types": "^18.6.1",
         "ajv": "^8.11.0"
       },
       "dependencies": {
@@ -17999,11 +18025,11 @@
       }
     },
     "@commitlint/ensure": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-18.1.0.tgz",
-      "integrity": "sha512-CkPzJ9UBumIo54VDcpmBlaVX81J++wzEhN3DJH9+6PaLeiIG+gkSx8t7C2gfwG7PaiW4HzQtdQlBN5ab+c4vFQ==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-18.6.1.tgz",
+      "integrity": "sha512-BPm6+SspyxQ7ZTsZwXc7TRQL5kh5YWt3euKmEIBZnocMFkJevqs3fbLRb8+8I/cfbVcAo4mxRlpTPfz8zX7SnQ==",
       "requires": {
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/types": "^18.6.1",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.snakecase": "^4.1.1",
@@ -18012,51 +18038,50 @@
       }
     },
     "@commitlint/execute-rule": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-18.1.0.tgz",
-      "integrity": "sha512-w3Vt4K+O7+nSr9/gFSEfZ1exKUOPSlJaRpnk7Y+XowEhvwT7AIk1HNANH+gETf0zGZ020+hfiMW/Ome+SNCUsg=="
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-18.6.1.tgz",
+      "integrity": "sha512-7s37a+iWyJiGUeMFF6qBlyZciUkF8odSAnHijbD36YDctLhGKoYltdvuJ/AFfRm6cBLRtRk9cCVPdsEFtt/2rg=="
     },
     "@commitlint/format": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-18.1.0.tgz",
-      "integrity": "sha512-So/w217tGWMZZb1yXcUFNF2qFLyYtSVqbnGoMbX8a+JKcG4oB11Gc1adS0ssUOMivtiNpaLtkSHFynyiwtJtiQ==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-18.6.1.tgz",
+      "integrity": "sha512-K8mNcfU/JEFCharj2xVjxGSF+My+FbUHoqR+4GqPGrHNqXOGNio47ziiR4HQUPKtiNs05o8/WyLBoIpMVOP7wg==",
       "requires": {
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/types": "^18.6.1",
         "chalk": "^4.1.0"
       }
     },
     "@commitlint/is-ignored": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-18.1.0.tgz",
-      "integrity": "sha512-fa1fY93J/Nx2GH6r6WOLdBOiL7x9Uc1N7wcpmaJ1C5Qs6P+rPSUTkofe2IOhSJIJoboHfAH6W0ru4xtK689t0Q==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-18.6.1.tgz",
+      "integrity": "sha512-MOfJjkEJj/wOaPBw5jFjTtfnx72RGwqYIROABudOtJKW7isVjFe9j0t8xhceA02QebtYf4P/zea4HIwnXg8rvA==",
       "requires": {
-        "@commitlint/types": "^18.1.0",
-        "semver": "7.5.4"
+        "@commitlint/types": "^18.6.1",
+        "semver": "7.6.0"
       }
     },
     "@commitlint/lint": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-18.1.0.tgz",
-      "integrity": "sha512-LGB3eI5UYu5LLayibNrRM4bSbowr1z9uyqvp0c7+0KaSJi+xHxy/QEhb6fy4bMAtbXEvygY0sUu9HxSWg41rVQ==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-18.6.1.tgz",
+      "integrity": "sha512-8WwIFo3jAuU+h1PkYe5SfnIOzp+TtBHpFr4S8oJWhu44IWKuVx6GOPux3+9H1iHOan/rGBaiacicZkMZuluhfQ==",
       "requires": {
-        "@commitlint/is-ignored": "^18.1.0",
-        "@commitlint/parse": "^18.1.0",
-        "@commitlint/rules": "^18.1.0",
-        "@commitlint/types": "^18.1.0"
+        "@commitlint/is-ignored": "^18.6.1",
+        "@commitlint/parse": "^18.6.1",
+        "@commitlint/rules": "^18.6.1",
+        "@commitlint/types": "^18.6.1"
       }
     },
     "@commitlint/load": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-18.2.0.tgz",
-      "integrity": "sha512-xjX3d3CRlOALwImhOsmLYZh14/+gW/KxsY7+bPKrzmGuFailf9K7ckhB071oYZVJdACnpY4hDYiosFyOC+MpAA==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-18.6.1.tgz",
+      "integrity": "sha512-p26x8734tSXUHoAw0ERIiHyW4RaI4Bj99D8YgUlVV9SedLf8hlWAfyIFhHRIhfPngLlCe0QYOdRKYFt8gy56TA==",
       "requires": {
-        "@commitlint/config-validator": "^18.1.0",
-        "@commitlint/execute-rule": "^18.1.0",
-        "@commitlint/resolve-extends": "^18.1.0",
-        "@commitlint/types": "^18.1.0",
-        "@types/node": "^18.11.9",
+        "@commitlint/config-validator": "^18.6.1",
+        "@commitlint/execute-rule": "^18.6.1",
+        "@commitlint/resolve-extends": "^18.6.1",
+        "@commitlint/types": "^18.6.1",
         "chalk": "^4.1.0",
-        "cosmiconfig": "^8.0.0",
+        "cosmiconfig": "^8.3.6",
         "cosmiconfig-typescript-loader": "^5.0.0",
         "lodash.isplainobject": "^4.0.6",
         "lodash.merge": "^4.6.2",
@@ -18099,24 +18124,24 @@
       }
     },
     "@commitlint/message": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-18.1.0.tgz",
-      "integrity": "sha512-8dT/jJg73wf3o2Mut/fqEDTpBYSIEVtX5PWyuY/0uviEYeheZAczFo/VMIkeGzhJJn1IrcvAwWsvJ1lVGY2I/w=="
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-18.6.1.tgz",
+      "integrity": "sha512-VKC10UTMLcpVjMIaHHsY1KwhuTQtdIKPkIdVEwWV+YuzKkzhlI3aNy6oo1eAN6b/D2LTtZkJe2enHmX0corYRw=="
     },
     "@commitlint/parse": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-18.1.0.tgz",
-      "integrity": "sha512-23yv8uBweXWYn8bXk4PjHIsmVA+RkbqPh2h7irupBo2LthVlzMRc4LM6UStasScJ4OlXYYaWOmuP7jcExUF50Q==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-18.6.1.tgz",
+      "integrity": "sha512-eS/3GREtvVJqGZrwAGRwR9Gdno3YcZ6Xvuaa+vUF8j++wsmxrA2En3n0ccfVO2qVOLJC41ni7jSZhQiJpMPGOQ==",
       "requires": {
-        "@commitlint/types": "^18.1.0",
-        "conventional-changelog-angular": "^6.0.0",
+        "@commitlint/types": "^18.6.1",
+        "conventional-changelog-angular": "^7.0.0",
         "conventional-commits-parser": "^5.0.0"
       },
       "dependencies": {
         "conventional-changelog-angular": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
-          "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
+          "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
           "requires": {
             "compare-func": "^2.0.0"
           }
@@ -18158,38 +18183,24 @@
       }
     },
     "@commitlint/read": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-18.1.0.tgz",
-      "integrity": "sha512-rzfzoKUwxmvYO81tI5o1371Nwt3vhcQR36oTNfupPdU1jgSL3nzBIS3B93LcZh3IYKbCIMyMPN5WZ10BXdeoUg==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-18.6.1.tgz",
+      "integrity": "sha512-ia6ODaQFzXrVul07ffSgbZGFajpe8xhnDeLIprLeyfz3ivQU1dIoHp7yz0QIorZ6yuf4nlzg4ZUkluDrGN/J/w==",
       "dev": true,
       "requires": {
-        "@commitlint/top-level": "^18.1.0",
-        "@commitlint/types": "^18.1.0",
-        "fs-extra": "^11.0.0",
+        "@commitlint/top-level": "^18.6.1",
+        "@commitlint/types": "^18.6.1",
         "git-raw-commits": "^2.0.11",
         "minimist": "^1.2.6"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "11.1.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-          "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
       }
     },
     "@commitlint/resolve-extends": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-18.1.0.tgz",
-      "integrity": "sha512-3mZpzOEJkELt7BbaZp6+bofJyxViyObebagFn0A7IHaLARhPkWTivXdjvZHS12nAORftv88Yhbh8eCPKfSvB7g==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-18.6.1.tgz",
+      "integrity": "sha512-ifRAQtHwK+Gj3Bxj/5chhc4L2LIc3s30lpsyW67yyjsETR6ctHAHRu1FSpt0KqahK5xESqoJ92v6XxoDRtjwEQ==",
       "requires": {
-        "@commitlint/config-validator": "^18.1.0",
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/config-validator": "^18.6.1",
+        "@commitlint/types": "^18.6.1",
         "import-fresh": "^3.0.0",
         "lodash.mergewith": "^4.6.2",
         "resolve-from": "^5.0.0",
@@ -18197,14 +18208,14 @@
       }
     },
     "@commitlint/rules": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-18.1.0.tgz",
-      "integrity": "sha512-VJNQ674CRv4znI0DbsjZLVnn647J+BTxHGcrDIsYv7c99gW7TUGeIe5kL80G7l8+5+N0se8v9yn+Prr8xEy6Yw==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-18.6.1.tgz",
+      "integrity": "sha512-kguM6HxZDtz60v/zQYOe0voAtTdGybWXefA1iidjWYmyUUspO1zBPQEmJZ05/plIAqCVyNUTAiRPWIBKLCrGew==",
       "requires": {
-        "@commitlint/ensure": "^18.1.0",
-        "@commitlint/message": "^18.1.0",
-        "@commitlint/to-lines": "^18.1.0",
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/ensure": "^18.6.1",
+        "@commitlint/message": "^18.6.1",
+        "@commitlint/to-lines": "^18.6.1",
+        "@commitlint/types": "^18.6.1",
         "execa": "^5.0.0"
       }
     },
@@ -18301,23 +18312,23 @@
       }
     },
     "@commitlint/to-lines": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-18.1.0.tgz",
-      "integrity": "sha512-aHIoSDjG0ckxPLYDpODUeSLbEKmF6Jrs1B5JIssbbE9eemBtXtjm9yzdiAx9ZXcwoHlhbTp2fbndDb3YjlvJag=="
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-18.6.1.tgz",
+      "integrity": "sha512-Gl+orGBxYSNphx1+83GYeNy5N0dQsHBQ9PJMriaLQDB51UQHCVLBT/HBdOx5VaYksivSf5Os55TLePbRLlW50Q=="
     },
     "@commitlint/top-level": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-18.1.0.tgz",
-      "integrity": "sha512-1/USHlolIxJlsfLKecSXH+6PDojIvnzaJGPYwF7MtnTuuXCNQ4izkeqDsRuNMe9nU2VIKpK9OT8Q412kGNmgGw==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-18.6.1.tgz",
+      "integrity": "sha512-HyiHQZUTf0+r0goTCDs/bbVv/LiiQ7AVtz6KIar+8ZrseB9+YJAIo8HQ2IC2QT1y3N1lbW6OqVEsTHjbT6hGSw==",
       "dev": true,
       "requires": {
         "find-up": "^5.0.0"
       }
     },
     "@commitlint/types": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-18.1.0.tgz",
-      "integrity": "sha512-65vGxZmbs+2OVwEItxhp3Ul7X2m2LyLfifYI/NdPwRqblmuES2w2aIRhIjb7cwUIBHHSTT8WXj4ixVHQibmvLQ==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-18.6.1.tgz",
+      "integrity": "sha512-gwRLBLra/Dozj2OywopeuHj2ac26gjGkz2cZ+86cTJOdtWfiRRr4+e77ZDAGc6MDWxaWheI+mAV5TLWWRwqrFg==",
       "requires": {
         "chalk": "^4.1.0"
       }
@@ -27561,9 +27572,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   "dependencies": {
     "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.0",
-    "@commitlint/config-angular": "^18.1.0",
-    "@commitlint/config-conventional": "^18.1.0",
-    "@commitlint/config-lerna-scopes": "^18.1.0",
-    "@commitlint/config-patternplate": "^18.1.0",
-    "@commitlint/ensure": "^18.1.0",
-    "@commitlint/format": "^18.1.0",
-    "@commitlint/lint": "^18.1.0",
-    "@commitlint/load": "^18.2.0",
+    "@commitlint/config-angular": "^18.6.1",
+    "@commitlint/config-conventional": "^18.6.3",
+    "@commitlint/config-lerna-scopes": "^18.6.1",
+    "@commitlint/config-patternplate": "^18.6.1",
+    "@commitlint/ensure": "^18.6.1",
+    "@commitlint/format": "^18.6.1",
+    "@commitlint/lint": "^18.6.1",
+    "@commitlint/load": "^18.6.1",
     "commitlint-config-jira": "^1.6.4",
     "commitlint-plugin-function-rules": "^2.0.2",
     "commitlint-plugin-jira-rules": "^1.6.4",
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@babel/core": "^7.19.3",
     "@babel/preset-env": "^7.19.3",
-    "@commitlint/cli": "^18.2.0",
+    "@commitlint/cli": "^18.6.1",
     "@commitlint/test": "^9.0.1",
     "@commitlint/test-environment": "^9.0.1",
     "@jest/globals": "^29.4.2",
@@ -69,6 +69,6 @@
     "yaml": "^2.1.3"
   },
   "overrides": {
-    "@commitlint/lint": "^18.1.0"
+    "@commitlint/lint": "^18.6.1"
   }
 }


### PR DESCRIPTION
This fixes #760 properly, without breaking changes. We'll upgrade commitlint to v19 in a major change to the version.