### PR TITLE
feat: handle merge_group event - get squashed commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,66 @@ jobs:
 
 Alternatively, you can run on other event types such as `on: [push]`. In that case the action will lint the push event's commit(s) instead of linting commits from a pull request. You can also combine `push` and `pull_request` together in the same workflow.
 
+### Using with GitHub Merge Queues
+
+GitHub's [merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) is a feature that allows you to queue pull requests for merging once they meet certain criteria. When using merge queues, you need to ensure that your workflows are set up to handle the merge_group event, which is triggered when pull requests are added to the merge queue.
+
+#### Workflow Configuration
+
+To use the commitlint-github-action with merge queues, you need to set up a workflow that listens to the merge_group event. Here's an example of how to configure your workflow:
+
+```yaml
+name: Lint Commit Messages in Merge Queue
+
+on:
+  merge_group:
+    types:
+      - checks_requested
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.sha }}
+
+      - uses: wagoid/commitlint-github-action@v6
+```
+
+#### Important Note:
+
+To ensure that the merge_group event triggers correctly, you need to have **at least one workflow that responds to the pull_request event** with a job named the same as the one in your merge_group workflow (**commitlint** in this example). This is necessary because the merge queue relies on the existence of status checks from the pull request context.
+
+Here's a minimal pull_request workflow to satisfy this requirement:
+
+```yaml
+name: Placeholder Workflow for Merge Queue
+
+on:
+  pull_request:
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+```
+
+This workflow can also be a meaningful one that checks out the commits in your PR and runs other checks, but it must have a job named **commitlint**.
+
+### Enabling Merge Queues in Your Repository
+
+Before you can use merge queues, you need to enable the feature in your repository settings:
+
+- Go to your repository's Settings > Branches.
+- Under Branch protection rules, edit the rule for your target branch (e.g. master).
+- Enable Require merge queue.
+- Specify your new job (e.g. commitlint) and any other required status checks, that must pass before merging.
+
+For more information on configuring merge queues, refer to the [GitHub documentation on managing a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).
+
 ## Inputs
 
 You can supply these inputs to the `wagoid/commitlint-github-action@v6` step.

--- a/action.yml
+++ b/action.yml
@@ -3,17 +3,18 @@ description: Lints Pull Request commit messages with commitlint
 author: Wagner Santos
 inputs:
   configFile:
-    description: Commitlint config file. If the file doesn't exist, config-conventional settings will be
+    description:
+      Commitlint config file. If the file doesn't exist, config-conventional settings will be
       loaded as a fallback.
     default: ./commitlint.config.mjs
     required: false
   failOnWarnings:
     description: Whether you want to fail on warnings or not
-    default: "false"
+    default: 'false'
     required: false
   failOnErrors:
     description: Whether you want to fail on errors or not
-    default: "true"
+    default: 'true'
     required: true
   helpURL:
     description: Link to a page explaining your commit message convention
@@ -21,7 +22,7 @@ inputs:
     required: false
   commitDepth:
     description: When set to a valid Integer value - X, considers only the latest X number of commits.
-    default: ""
+    default: ''
     required: false
   token:
     description: >
@@ -35,7 +36,7 @@ outputs:
     description: The error and warning messages for each one of the analyzed commits
 runs:
   using: docker
-  image: docker://wagoid/commitlint-github-action:6.1.2
+  image: docker://ghcr.io/yossisaadi/commitlint-github-action:latest
 branding:
   icon: check-square
   color: blue

--- a/action.yml
+++ b/action.yml
@@ -3,18 +3,17 @@ description: Lints Pull Request commit messages with commitlint
 author: Wagner Santos
 inputs:
   configFile:
-    description:
-      Commitlint config file. If the file doesn't exist, config-conventional settings will be
+    description: Commitlint config file. If the file doesn't exist, config-conventional settings will be
       loaded as a fallback.
     default: ./commitlint.config.mjs
     required: false
   failOnWarnings:
     description: Whether you want to fail on warnings or not
-    default: 'false'
+    default: "false"
     required: false
   failOnErrors:
     description: Whether you want to fail on errors or not
-    default: 'true'
+    default: "true"
     required: true
   helpURL:
     description: Link to a page explaining your commit message convention
@@ -22,7 +21,7 @@ inputs:
     required: false
   commitDepth:
     description: When set to a valid Integer value - X, considers only the latest X number of commits.
-    default: ''
+    default: ""
     required: false
   token:
     description: >
@@ -36,7 +35,7 @@ outputs:
     description: The error and warning messages for each one of the analyzed commits
 runs:
   using: docker
-  image: docker://ghcr.io/yossisaadi/commitlint-github-action:latest
+  image: docker://wagoid/commitlint-github-action:6.1.2
 branding:
   icon: check-square
   color: blue

--- a/src/action.mjs
+++ b/src/action.mjs
@@ -7,6 +7,7 @@ import { format } from '@commitlint/format'
 import load from '@commitlint/load'
 import generateOutputs from './generateOutputs.mjs'
 
+const mergeGroupEvent = 'merge_group'
 const pullRequestEvent = 'pull_request'
 const pullRequestTargetEvent = 'pull_request_target'
 const pullRequestEvents = [pullRequestEvent, pullRequestTargetEvent]
@@ -65,7 +66,21 @@ const getPullRequestEventCommits = async () => {
   }))
 }
 
+const getMergeGroupEventCommits = async () => {
+  const { merge_group } = eventContext.payload
+
+  return [
+    {
+      message: merge_group.head_commit.message,
+      hash: merge_group.head_sha,
+    },
+  ]
+}
+
 const getEventCommits = async () => {
+  if (GITHUB_EVENT_NAME === mergeGroupEvent) {
+    return getMergeGroupEventCommits()
+  }
   if (pullRequestEvents.includes(GITHUB_EVENT_NAME)) {
     return getPullRequestEventCommits()
   }

--- a/src/testUtils.mjs
+++ b/src/testUtils.mjs
@@ -77,3 +77,32 @@ export const buildResponseCommit = (sha, message) => ({
     message,
   },
 })
+
+export const createMergeGroupEventPayload = async (cwd, mergeGroupData) => {
+  const payload = {
+    action: 'checks_requested',
+    merge_group: mergeGroupData,
+    repository: {
+      owner: {
+        login: 'wagoid',
+      },
+      name: 'commitlint-github-action',
+    },
+  }
+
+  const eventPath = path.join(cwd, 'mergeGroupEventPayload.json')
+
+  updateEnvVars({
+    GITHUB_EVENT_PATH: eventPath,
+    GITHUB_EVENT_NAME: 'merge_group',
+    GITHUB_REPOSITORY: 'wagoid/commitlint-github-action',
+  })
+  await writeFile(eventPath, JSON.stringify(payload), 'utf8')
+}
+
+export const updateMergeGroupEnvVars = (cwd) => {
+  updateEnvVars({
+    GITHUB_WORKSPACE: cwd,
+    GITHUB_EVENT_NAME: 'merge_group',
+  })
+}


### PR DESCRIPTION
# Support for GitHub Merge Queue (merge_group Event)

## Summary

This pull request adds support for GitHub's merge queue functionality by handling the `merge_group` event in the `commitlint-github-action`. It enables users who utilize GitHub's merge queue feature to lint commit messages effectively during the merge process.
Resolve #744 #757

## Changes

1. Update `action.mjs` and tests to Support `merge_group` Event:
- Added logic to detect when the action is triggered by a `merge_group` event.
- Updated the way commits are retrieved in this context to ensure the correct commits are linted.
- Verified that the correct commits are being linted in this context.

2. Update README
- Added a new section on using the action with GitHub Merge Queues:
	- Provided examples of workflows that listen to the `merge_group` event.
	- Explained necessary configurations and considerations when using the merge queue.

---

## Testing
I've tested the updated action extensively to ensure it works correctly with the `merge_group` event.

Test Repository: [yossi-test-org/test-merge-queue](https://github.com/yossi-test-org/test-merge-queue)
Test Pull Request: [PR #24](https://github.com/yossi-test-org/test-merge-queue/pull/24)

### Test Steps
1. Set Up Merge Queue:
- Enabled the merge queue feature in the test repository.
- Configured branch protection rules to require the `commitlint` status check.

2. Created Workflows:
- Added a workflow that listens to the `merge_group` event and runs the `commitlint` action.
- Added a placeholder workflow for the `pull_request` event with a job named `commitlint` to satisfy merge queue requirements.

3. Tested Pull Requests:
- Opened pull request with various commit messages to test linting behavior.
- Added pull request to the merge queue to trigger the `merge_group` event.

4. Verified Action Execution:
- Confirmed that the `commitlint` action runs successfully during the `merge_group` event on the squashed commit.
- Checked that the action lints the correct commit and reports any issues appropriately.

For testing I also pushed the image to a container registry and ran the workflow against it (https://github.com/users/YossiSaadi/packages/container/package/commitlint-github-action)