### PR TITLE
fix: pin Docker image by digest to prevent supply chain attacks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ outputs:
     description: The error and warning messages for each one of the analyzed commits
 runs:
   using: docker
-  image: docker://wagoid/commitlint-github-action:6.2.1
+  image: docker://wagoid/commitlint-github-action@sha256:86a04e0a99128551a7555c269d2b675c3c85f61358cf7dd558f6b873b66f561a
 branding:
   icon: check-square
   color: blue


### PR DESCRIPTION
## Summary

Replace the mutable Docker Hub tag reference in `action.yml` with an immutable digest pin.

## Why this matters

Users of this action follow [GitHub's security guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and pin actions by commit SHA — e.g. `wagoid/commitlint-github-action@b948419...`. However, that SHA only pins `action.yml` itself. Because `action.yml` references the Docker image by **tag** (`6.2.1`), the actual code that runs is whatever Docker Hub resolves for that tag at pull time.

Docker tags are mutable. If the Docker Hub account were compromised (or the tag were accidentally overwritten), every workflow pinned to this action would silently begin running different code — even though their SHA pin never changed. This breaks the security guarantee that SHA-pinning is supposed to provide.

Pinning by **image digest** (`@sha256:...`) makes the reference immutable. The digest is a content hash of the image manifest, so it is impossible to change what it resolves to. This brings the Docker image reference in line with the same security model that consumers already expect from SHA-pinning the action.

## What changes

Only one line in `action.yml` — the `image:` reference. No functional change. The digest `sha256:86a04e0a...` resolves to the exact same image that the `6.2.1` tag currently points to.

## Note for future releases

When publishing a new version, the release process would need to update the digest in `action.yml` to match the newly pushed image. This could be automated in CI by capturing `docker inspect --format='{{index .RepoDigests 0}}'` after the image push and updating `action.yml` before the release commit.
