### PR TITLE
docs(action): fix input and output descriptions in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,8 +3,9 @@ description: Lints Pull Request commit messages with commitlint
 author: Wagner Santos
 inputs:
   configFile:
-    description: Commitlint config file. If the file doesn't exist, config-conventional settings will be
-      loaded as a fallback.
+    description: >
+      Commitlint config file. The .js extension is not supported; use .mjs instead.
+      If the file doesn't exist, config-conventional settings will be loaded as a fallback.
     default: ./commitlint.config.mjs
     required: false
   failOnWarnings:
@@ -14,13 +15,15 @@ inputs:
   failOnErrors:
     description: Whether you want to fail on errors or not
     default: "true"
-    required: true
+    required: false
   helpURL:
     description: Link to a page explaining your commit message convention
     default: https://github.com/conventional-changelog/commitlint/#what-is-commitlint
     required: false
   commitDepth:
-    description: When set to a valid Integer value - X, considers only the latest X number of commits.
+    description: >
+      When set to an integer value X, considers only the first X commits from the returned commit list.
+      Values less than or equal to zero, or values that cannot be parsed as an integer, are ignored and all commits are linted.
     default: ""
     required: false
   token:
@@ -32,7 +35,11 @@ inputs:
     required: false
 outputs:
   results:
-    description: The error and warning messages for each one of the analyzed commits
+    description: >
+      JSON-encoded string representing an array of lint results for each analyzed
+      commit; parse it with fromJSON in workflows. Each entry contains:
+      hash (commit SHA), message (commit message), valid (boolean),
+      errors (array of strings), warnings (array of strings).
 runs:
   using: docker
   image: docker://wagoid/commitlint-github-action:6.2.1


### PR DESCRIPTION
## Summary
Corrects inaccurate and incomplete documentation in `action.yml` without changing any runtime behavior.
 
 ## Changes
- **`configFile`**: Added an explicit note that the `.js` extension is not supported and causes a hard failure — users must use `.mjs` instead.
- **`failOnErrors`**: Changed `required: true` to `required: false`. The field has a default value of `"true"`, making `required: true` semantically contradictory per the GitHub Actions spec.
- **`commitDepth`**: Extended the description to document that zero, negative, and non-numeric values are silently ignored and all commits are linted.
- **`results` output**: Replaced the vague description ("error and warning messages") with the actual JSON schema — an array of objects each containing `hash`, `message`, `valid`, `errors`, and `warnings`.
 
 ## Motivation
The previous descriptions were either incorrect (`required: true` on a field with a default), missing critical constraints (`.js` not allowed for `configFile`), or too vague to be useful (`results` output structure). Users relying solely on `action.yml` for integration would hit confusing failures or not know how to consume the `results` output.
 
 ## Impact
 - No behavior changes — documentation only.
- Backward compatible: no input or output names were changed.
- The `required: false` fix on `failOnErrors` has no runtime effect since the field already carries a default; it only corrects how tooling and UIs surface the field.
 
 ## Testing 
No code paths were modified. Changes were validated by cross-referencing each field against the source implementation in `src/action.mjs` and `src/generateOutputs.mjs`.